### PR TITLE
Fix use of template literals in the dropdown item

### DIFF
--- a/src/bs4-autocomplete.ts
+++ b/src/bs4-autocomplete.ts
@@ -72,7 +72,7 @@ interface JQuery {
                 compare = entry.label.toLowerCase().indexOf(lookup.toLowerCase()) >= 0;
             }
             if (compare) {
-                let itemHTML = $(`<button type="button" class="dropdown-item ${opts.labelClass ? ${opts.labelClass}` : ``}" data-value="${entry.value}" />`);
+                let itemHTML = $(`<button type="button" class="dropdown-item ${opts.labelClass ? `${opts.labelClass}` : ``}" data-value="${entry.value}" />`);
 
                 let valueHTML = createItem(lookup, entry, opts);
                 itemHTML.append(valueHTML);

--- a/src/bs4-autocomplete.ts
+++ b/src/bs4-autocomplete.ts
@@ -72,7 +72,7 @@ interface JQuery {
                 compare = entry.label.toLowerCase().indexOf(lookup.toLowerCase()) >= 0;
             }
             if (compare) {
-                let itemHTML = $('<button type="button" class="dropdown-item ${opts.labelClass ? `${opts.labelClass}` : ``}" data-value="${entry.value}" />');
+                let itemHTML = $(`<button type="button" class="dropdown-item ${opts.labelClass ? ${opts.labelClass}` : ``}" data-value="${entry.value}" />`);
 
                 let valueHTML = createItem(lookup, entry, opts);
                 itemHTML.append(valueHTML);


### PR DESCRIPTION
I noticed that the class names in the dropdown item looked a little off:

![image](https://user-images.githubusercontent.com/10030148/102812508-1f584a00-4395-11eb-93d8-e5761d64fd09.png)

I've replaced single quotes with backticks in the appropriate place so that the drowdown item's `class` and `data-value` tags evaluate as intended.